### PR TITLE
Add basic MPU-401 MIDI output support

### DIFF
--- a/src/system.sv
+++ b/src/system.sv
@@ -83,6 +83,7 @@ module system (
     // Debug stream up to UART bridge
     output  [7:0] dbg_uart_byte,
     output        dbg_uart_we,
+    output        mpu_uart_tx,
 
     // SignalTap anchors for the boot-ROM / reset-vector path.
     output [31:0] dbg_sd_avm_address,
@@ -685,6 +686,7 @@ wire [7:0] iobus_readdata8 =
 	( ps2_io_cs|ps2_ctl_cs                   ) ? ps2_readdata      :
 	( rtc_cs                                 ) ? rtc_readdata      :
 	( sb_cs|fm_cs                            ) ? sound_readdata    :
+	( mpu_cs                                 ) ? mpu_readdata      :
 	( vga_b_cs|vga_c_cs|vga_d_cs             ) ? vga_io_readdata   :
 	( sysctl_cs                              ) ? 8'hE9             :
 	                                             8'hFF;
@@ -738,6 +740,9 @@ always @(*) begin
 	rtc_cs        = ({iobus_address[15:1], 1'd0} == 16'h0070);
 	fm_cs         = ({iobus_address[15:2], 2'd0} == 16'h0388);
 	sb_cs         = ({iobus_address[15:4], 4'd0} == 16'h0220);
+	uart1_cs      = ({iobus_address[15:3], 3'd0} == 16'h03F8); // COM1
+	uart2_cs      = ({iobus_address[15:3], 3'd0} == 16'h02F8); // COM2
+	mpu_cs        = ({iobus_address[15:1], 1'd0} == 16'h0330); // MPU-401 330/331
 	vga_b_cs      = ({iobus_address[15:4], 4'd0} == 16'h03B0);
 	vga_c_cs      = ({iobus_address[15:4], 4'd0} == 16'h03C0);
 	vga_d_cs      = ({iobus_address[15:4], 4'd0} == 16'h03D0);
@@ -1496,6 +1501,95 @@ always @(posedge clk_sys) begin
         end
     end
 end
+
+
+// -----------------------------------------------------------------------------
+// Minimal MPU-401 UART/dumb mode output.
+// Writes to port 330h are serialized to MiSTer HPS UART/MidiLink.
+// Port 331h is treated as MPU command/status.
+// This is not full intelligent MPU-401; it is enough for basic UART-mode MIDI.
+// -----------------------------------------------------------------------------
+
+reg  [7:0] mpu_fifo [0:255];
+reg  [7:0] mpu_fifo_wr;
+reg  [7:0] mpu_fifo_rd;
+reg  [8:0] mpu_fifo_count;
+
+reg  [7:0] mpu_tx_data;
+reg        mpu_tx_wr;
+wire       mpu_tx_busy;
+
+reg        mpu_ack_pending;
+
+wire       mpu_fifo_full  = (mpu_fifo_count == 9'd256);
+wire       mpu_fifo_empty = (mpu_fifo_count == 9'd0);
+
+wire       mpu_data_write = iobus_write && mpu_cs && !iobus_address[0] && !mpu_fifo_full;
+wire       mpu_cmd_write  = iobus_write && mpu_cs &&  iobus_address[0];
+wire       mpu_data_read  = iobus_read  && mpu_cs && !iobus_address[0];
+wire       mpu_dequeue    = !mpu_tx_busy && !mpu_fifo_empty && !mpu_tx_wr;
+
+// MPU status register at 331h:
+// bit 7 = 0: ACK/data available to host
+// bit 7 = 1: no data available
+// bit 6 = 0: ready to accept command/data
+// bit 6 = 1: FIFO full
+assign mpu_readdata = iobus_address[0]
+                    ? (mpu_ack_pending ? 8'h00 : (mpu_fifo_full ? 8'hC0 : 8'h80))
+                    : 8'hFE;
+
+always @(posedge clk_sys) begin
+    mpu_tx_wr <= 1'b0;
+
+    if (reset) begin
+        mpu_fifo_wr     <= 8'd0;
+        mpu_fifo_rd     <= 8'd0;
+        mpu_fifo_count  <= 9'd0;
+        mpu_tx_data     <= 8'd0;
+        mpu_ack_pending <= 1'b0;
+    end else begin
+        // Port 331h: MPU command. Return generic ACK 0xFE on port 330h.
+        if (mpu_cmd_write) begin
+            mpu_ack_pending <= 1'b1;
+        end
+
+        // Port 330h read consumes ACK.
+        if (mpu_data_read && mpu_ack_pending) begin
+            mpu_ack_pending <= 1'b0;
+        end
+
+        // Port 330h write: MIDI data byte.
+        if (mpu_data_write) begin
+            mpu_fifo[mpu_fifo_wr] <= iobus_writedata_byte;
+            mpu_fifo_wr <= mpu_fifo_wr + 8'd1;
+        end
+
+        // Serialize FIFO to UART.
+        if (mpu_dequeue) begin
+            mpu_tx_data <= mpu_fifo[mpu_fifo_rd];
+            mpu_fifo_rd <= mpu_fifo_rd + 8'd1;
+            mpu_tx_wr   <= 1'b1;
+        end
+
+        case ({mpu_data_write, mpu_dequeue})
+            2'b10: mpu_fifo_count <= mpu_fifo_count + 9'd1;
+            2'b01: mpu_fifo_count <= mpu_fifo_count - 9'd1;
+            default: mpu_fifo_count <= mpu_fifo_count;
+        endcase
+    end
+end
+
+uart_tx_V2 mpu_uart_tx_i
+(
+    .clk      (clk_sys),
+    .din      (mpu_tx_data),
+    .wr_en    (mpu_tx_wr),
+    .tx_busy  (mpu_tx_busy),
+    .tx_p     (mpu_uart_tx)
+);
+
+defparam mpu_uart_tx_i.clk_freq  = SYS_FREQ;
+defparam mpu_uart_tx_i.uart_freq = 31250;
 
 // Export debug byte for UART bridge to wrap as type 0x07
 wire bios_dbg_write = iobus_write && sysctl_cs;

--- a/z386_mister.sv
+++ b/z386_mister.sv
@@ -107,7 +107,7 @@ localparam DCACHE_SET_BITS = 8;   // dcache size: 8 = 16KB, 7 = 8KB (4 ways x 16
 localparam ICACHE_SET_BITS = 8;   // icache size: 8 = 16KB, 7 = 8KB
 
 localparam CONF_STR = {
-	"Z386;UART115200;",
+	"Z386;UART115200:4000000 (Turbo 115200),MIDI;",
 	"S0,IMGIMAVFD,Floppy A:;",
 	"S1,IMGIMAVFD,Floppy B:;",
 	"O12,Write Protect,None,A:,B:,A: & B:;",
@@ -281,6 +281,7 @@ wire [7:0]  uart_mode;
 wire [31:0] uart_speed;
 wire        debug_uart_tx;
 wire        debug_uart_busy;
+wire        mpu_uart_tx;
 reg   [7:0] debug_uart_data;
 reg         debug_uart_wr;
 reg   [7:0] debug_uart_fifo [0:255];
@@ -532,6 +533,7 @@ system #(
 
 	.dbg_uart_byte       (core_dbg_uart_byte),
 	.dbg_uart_we         (core_dbg_uart_we),
+   .mpu_uart_tx         (mpu_uart_tx),
 	.dbg_sd_avm_address  (),
 	.dbg_sd_avm_writedata(),
 	.dbg_sd_avm_write    (),
@@ -863,8 +865,10 @@ assign SD_CS         = 1'bz;
 assign DDRAM_CLK     = clk_sys;
 assign SDRAM_CLK     = clk_sdram;
 
+wire uart_midi_mode = (uart_mode != 8'd0);
+
 assign UART_RTS      = 1'b0;
-assign UART_TXD      = debug_uart_tx;
+assign UART_TXD      = uart_midi_mode ? mpu_uart_tx : debug_uart_tx;
 assign UART_DTR      = 1'b0;
 assign USER_OUT      = 7'h7F;
 


### PR DESCRIPTION
## Summary

This PR adds basic MPU-401 UART/dumb MIDI output support to z386_MiSTer.

## Changes

- Exposes MIDI in `CONF_STR`:
  `"Z386;UART115200:4000000 (Turbo 115200),MIDI;"`
- Adds a minimal MPU-401 UART/dumb output path at ports `330h/331h`.
- Writes to port `330h` are serialized to the MiSTer HPS UART/MidiLink path.
- Adds basic command ACK behavior through port `331h/330h`.
- Routes `UART_TXD` to the MPU MIDI UART when MiSTer UART mode is active.
- Uses `31250` baud for MIDI output, matching MidiLink MIDI baud behavior.

## Testing

Tested on real MiSTer hardware with MidiLink/MIDI at `31250` baud.

MIDI output works correctly with DOS games configured for:

- General MIDI / Roland
- MPU-401
- Port `330h`

Initial testing with `38400` baud produced incorrect/stuck notes, while `31250` baud fixed the MIDI stream.

## Notes

This is not a full intelligent MPU-401 implementation. It provides a basic UART/dumb MIDI output path suitable for software that writes MIDI bytes to port `330h`.
